### PR TITLE
chore: update libs for CVE-2024-45338 and CVE-2024-34156

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22.5-bookworm as build
+FROM golang:1.22.11-bookworm AS build
 WORKDIR /go/src/app
 COPY . ./
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/alpheya/sealed-secrets-ui
 
-go 1.22.5
+go 1.22.11
 
 require (
 	github.com/a-h/templ v0.2.747
@@ -33,7 +33,7 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	golang.org/x/net v0.24.0 // indirect
+	golang.org/x/net v0.33.0 // indirect
 	golang.org/x/oauth2 v0.10.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 	golang.org/x/term v0.19.0 // indirect


### PR DESCRIPTION
Update golang base image to 1.22.11 to get rid of CVE-2024-34156

Update golang.org/x/net for CVE-2024-45338

Fix Dockerfile with keyword "as" to "AS" to avoid warnings during the build